### PR TITLE
chore: Update release workflow trigger to manual dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
## Changes
- Update release workflow trigger from auto (push to main) to manual workflow dispatch
- Enables more controlled release process by requiring manual trigger