### PR TITLE
feat: eventName prop for DOMEvents

### DIFF
--- a/docs/src/content/components.mdx
+++ b/docs/src/content/components.mdx
@@ -54,6 +54,7 @@ function App() {
 
 - `type: DOMEventNames` - Event name (e.g., onClick, onFocus)
 - `params: unknown` - Event parameters
+- `eventName?: string` - A name for the event that will be used to trigger the event handler
 
 ## Click
 
@@ -84,6 +85,7 @@ function App() {
 ### Props
 
 - `params: unknown` - Click event parameters
+- `eventName?: string` - A name for the event that will be used to trigger the event handler
 
 ## Impression
 

--- a/src/__tests__/createTracker.test.tsx
+++ b/src/__tests__/createTracker.test.tsx
@@ -129,6 +129,28 @@ describe("events", () => {
 
     expect(focusFn).toHaveBeenCalledWith(focusEventParams, context, anyFn);
   });
+
+  it("DOMEvent's event name can be changed using eventName prop", async () => {
+    const context = { userId: "id" };
+    const focusEventParams = { a: 1 };
+    const CustomInput = ({ onInputFocus }: { onInputFocus?: () => void }) => {
+      return <input onFocus={onInputFocus} />;
+    };
+
+    const page = render(
+      <Track.Provider initialContext={context}>
+        <div>test</div>
+        <Track.DOMEvent type="onFocus" params={focusEventParams} eventName="onInputFocus">
+          <CustomInput />
+        </Track.DOMEvent>
+      </Track.Provider>,
+    );
+
+    page.getByRole("textbox").focus();
+    await sleep(1);
+
+    expect(focusFn).toHaveBeenCalledWith(focusEventParams, context, anyFn);
+  });
 });
 
 describe("page view", () => {

--- a/src/tracker/components/Click.tsx
+++ b/src/tracker/components/Click.tsx
@@ -1,0 +1,14 @@
+import type { DOMEventProps } from "./DOMEvent";
+import { DOMEvent } from "./DOMEvent";
+
+export interface ClickProps extends Omit<DOMEventProps, "type" | "onEventOccur"> {
+  onClick: () => Promise<void> | void;
+}
+
+export const Click = ({ children, onClick, eventName }: ClickProps) => {
+  return (
+    <DOMEvent eventName={eventName} type="onClick" onEventOccur={onClick}>
+      {children}
+    </DOMEvent>
+  );
+};

--- a/src/tracker/components/DOMEvent.tsx
+++ b/src/tracker/components/DOMEvent.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+import { isValidElement, cloneElement, Children } from "react";
+
+import type { DOMEventNames } from "../types";
+
+export interface DOMEventProps {
+  type: DOMEventNames;
+  children: ReactNode;
+  onEventOccur: () => Promise<void> | void;
+  eventName?: string;
+}
+
+export const DOMEvent = ({ children, type, onEventOccur, eventName = type }: DOMEventProps) => {
+  const child = Children.only(children);
+
+  return (
+    isValidElement<{ [key in string]?: (...args: any[]) => void }>(child) &&
+    cloneElement(child, {
+      ...child.props,
+      [eventName]: (...args: any[]) => {
+        onEventOccur?.();
+        if (child.props && typeof child.props?.[eventName] === "function") {
+          return child.props[type]?.(...args);
+        }
+      },
+    })
+  );
+};

--- a/src/tracker/components/Impression.tsx
+++ b/src/tracker/components/Impression.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+import { Children, cloneElement, isValidElement } from "react";
+
+import { useIntersectionObserver } from "../../hooks/useIntersectionObserver";
+import { useMergeRefs } from "../../hooks/useMergeRefs";
+import type { ImpressionOptions } from "../types";
+
+export interface ImpressionProps {
+  children: ReactNode;
+  onImpression: () => Promise<void>;
+  options?: ImpressionOptions;
+}
+
+export const Impression = ({ children, onImpression, options }: ImpressionProps) => {
+  const { ref: impressionRef } = useIntersectionObserver({
+    ...options,
+    onChange: (isIntersecting) => {
+      if (isIntersecting) onImpression();
+    },
+  });
+
+  const child = Children.only(children);
+  const hasRef = isValidElement(child) && (child as any)?.ref != null;
+  const ref = useMergeRefs<HTMLDivElement>(hasRef ? [(child as any).ref, impressionRef] : [impressionRef]);
+
+  return hasRef ? (
+    cloneElement(child as any, {
+      ref,
+    })
+  ) : (
+    // FIXME: not a good solution since it can cause style issues
+    <div aria-hidden ref={ref}>
+      {child}
+    </div>
+  );
+};

--- a/src/tracker/components/PageView.tsx
+++ b/src/tracker/components/PageView.tsx
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from "react";
+
+export interface PageViewProps {
+  onPageView: () => Promise<void>;
+}
+
+export const PageView = ({ onPageView }: PageViewProps) => {
+  const onPageViewRef = useRef<typeof onPageView>(onPageView);
+
+  useEffect(() => {
+    onPageViewRef.current?.();
+  }, [onPageViewRef]);
+
+  return null;
+};

--- a/src/tracker/index.tsx
+++ b/src/tracker/index.tsx
@@ -26,7 +26,7 @@ export function createTracker<Context, SendParams, EventParams, ImpressionParams
       throw new Error("useTracker must be used within a TrackerProvider");
     }
 
-    const scheduledDomEvents = {} as Partial<Record<DOMEventNames, (params: EventParams) => void>>;
+    const scheduledDomEvents = {} as Record<DOMEventNames, (params: EventParams) => void>;
     for (const key in trackerContext.tracker.DOMEvents) {
       scheduledDomEvents[key as DOMEventNames] = (params: EventParams) => {
         return trackerContext._schedule(() =>


### PR DESCRIPTION
I added `eventName` prop for cases when the `DOMEvent's` child component's event name isn't the original event handler name.
usage example
```tsx
      <Track.Provider initialContext={context}>
        <div>test</div>
        <Track.DOMEvent type="onFocus" params={focusEventParams} eventName="onInputFocus">
          <CustomInput />
        </Track.DOMEvent>
      </Track.Provider>,
```