### PR TITLE
fix(components): correct event handler reference in DOMEvent component

### DIFF
--- a/src/__tests__/createTracker.test.tsx
+++ b/src/__tests__/createTracker.test.tsx
@@ -125,6 +125,7 @@ describe("DOMEvents", () => {
     type Context = { userId: string };
     const context: Context = { userId: "id" };
     const focusEventParams = { a: 1 };
+
     const page = render(
       <Track.Provider initialContext={context}>
         <div>test</div>
@@ -143,6 +144,8 @@ describe("DOMEvents", () => {
   it("DOMEvent's event name can be changed using eventName prop", async () => {
     const context = { userId: "id" };
     const focusEventParams = { a: 1 };
+    const originalInputFocusFn = vi.fn();
+
     const CustomInput = ({ onInputFocus }: { onInputFocus?: () => void }) => {
       return <input onFocus={onInputFocus} />;
     };
@@ -151,7 +154,7 @@ describe("DOMEvents", () => {
       <Track.Provider initialContext={context}>
         <div>test</div>
         <Track.DOMEvent type="onFocus" params={focusEventParams} eventName="onInputFocus">
-          <CustomInput />
+          <CustomInput onInputFocus={originalInputFocusFn} />
         </Track.DOMEvent>
       </Track.Provider>,
     );
@@ -160,6 +163,7 @@ describe("DOMEvents", () => {
     await sleep(1);
 
     expect(focusFn).toHaveBeenCalledWith(focusEventParams, context, anyFn);
+    expect(originalInputFocusFn).toHaveBeenCalled();
   });
 });
 
@@ -273,7 +277,10 @@ describe("set context", () => {
     });
 
     pageViewFn.mockImplementationOnce((_, __, setContext) => {
-      setContext((prev: { userId: string; test: boolean }) => ({ ...prev, test: true }));
+      setContext((prev: { userId: string; test: boolean }) => ({
+        ...prev,
+        test: true,
+      }));
     });
 
     const page = render(

--- a/src/tracker/components/DOMEvent.tsx
+++ b/src/tracker/components/DOMEvent.tsx
@@ -4,30 +4,25 @@ import { isValidElement, cloneElement, Children } from "react";
 import type { DOMEventNames } from "../../types";
 
 export interface DOMEventProps {
-	type: DOMEventNames;
-	children: ReactNode;
-	onTrigger: () => Promise<void> | void;
-	eventName?: string;
+  type: DOMEventNames;
+  children: ReactNode;
+  onTrigger: () => Promise<void> | void;
+  eventName?: string;
 }
 
-export const DOMEvent = ({
-	children,
-	type,
-	onTrigger,
-	eventName = type,
-}: DOMEventProps) => {
-	const child = Children.only(children);
+export const DOMEvent = ({ children, type, onTrigger, eventName = type }: DOMEventProps) => {
+  const child = Children.only(children);
 
-	return (
-		isValidElement<{ [key in string]?: (...args: any[]) => void }>(child) &&
-		cloneElement(child, {
-			...child.props,
-			[eventName]: (...args: any[]) => {
-				onTrigger?.();
-				if (child.props && typeof child.props?.[eventName] === "function") {
-					return child.props[eventName]?.(...args);
-				}
-			},
-		})
-	);
+  return (
+    isValidElement<{ [key in string]?: (...args: any[]) => void }>(child) &&
+    cloneElement(child, {
+      ...child.props,
+      [eventName]: (...args: any[]) => {
+        onTrigger?.();
+        if (child.props && typeof child.props?.[eventName] === "function") {
+          return child.props[eventName]?.(...args);
+        }
+      },
+    })
+  );
 };

--- a/src/tracker/components/DOMEvent.tsx
+++ b/src/tracker/components/DOMEvent.tsx
@@ -4,25 +4,30 @@ import { isValidElement, cloneElement, Children } from "react";
 import type { DOMEventNames } from "../../types";
 
 export interface DOMEventProps {
-  type: DOMEventNames;
-  children: ReactNode;
-  onTrigger: () => Promise<void> | void;
-  eventName?: string;
+	type: DOMEventNames;
+	children: ReactNode;
+	onTrigger: () => Promise<void> | void;
+	eventName?: string;
 }
 
-export const DOMEvent = ({ children, type, onTrigger, eventName = type }: DOMEventProps) => {
-  const child = Children.only(children);
+export const DOMEvent = ({
+	children,
+	type,
+	onTrigger,
+	eventName = type,
+}: DOMEventProps) => {
+	const child = Children.only(children);
 
-  return (
-    isValidElement<{ [key in string]?: (...args: any[]) => void }>(child) &&
-    cloneElement(child, {
-      ...child.props,
-      [eventName]: (...args: any[]) => {
-        onTrigger?.();
-        if (child.props && typeof child.props?.[eventName] === "function") {
-          return child.props[type]?.(...args);
-        }
-      },
-    })
-  );
+	return (
+		isValidElement<{ [key in string]?: (...args: any[]) => void }>(child) &&
+		cloneElement(child, {
+			...child.props,
+			[eventName]: (...args: any[]) => {
+				onTrigger?.();
+				if (child.props && typeof child.props?.[eventName] === "function") {
+					return child.props[eventName]?.(...args);
+				}
+			},
+		})
+	);
 };


### PR DESCRIPTION
## Description
Fixed a bug in the DOMEvent component where the original event handler was incorrectly referenced. When using a custom event name via the `eventName` prop, the original handler was not being called correctly.

## Changes
Updated the reference from `child.props[type]` to `child.props[eventName]` to ensure the correct event handler is called

## Testing
- Verified the fix works by testing a component with a custom event name
- Confirmed that the original behavior works as expected with default event names

## Related Issues
(Reference any related issues if applicable)