### PR TITLE
chore: add Prettier scripts to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,10 @@
     "lint": "eslint --cache --ignore-pattern=docs/** .",
     "prepack": "pnpm build",
     "prepare": "husky",
-    "release": "pnpm build && npm publish"
+    "release": "pnpm build && npm publish",
+    "format": "prettier --write --ignore-pattern \"docs/**\" .",
+    "format:check": "prettier --check --ignore-pattern \"docs/**\" .",
+    "format:file": "prettier --write"
   },
   "main": "dist/index.cjs",
   "module": "dist/index.js",


### PR DESCRIPTION
## Description

This PR adds dedicated npm scripts for Prettier formatting to make it easier for contributors to maintain consistent code style across the project.

As discussed in issue #24, these scripts exclude the `docs/` directory to avoid problems with the Tailwind CSS plugin that's only configured for the docs subfolder.

### Changes

Added the following scripts to `package.json`
- `format`: Runs Prettier on all project files except docs (`prettier --write --ignore-pattern "docs/**" .`)
- `format:check`: Checks which files need formatting without modifying them (`prettier --check --ignore-pattern "docs/**" .`)
- `format:file`: Formats a specific file (usage: `pnpm format:file path/to/file.ts`)

### Usage Examples

```bash
# Format all files in the project (excluding docs)
pnpm format

# Check which files need formatting (excluding docs)
pnpm format:check

# Format a specific file
pnpm format:file src/components/MyComponent.tsx