### PR TITLE
docs: throw NO API KEY Error only when it is production

### DIFF
--- a/docs/src/tracker/createTracker.ts
+++ b/docs/src/tracker/createTracker.ts
@@ -18,13 +18,14 @@ const track = isDev ? console.log : amplitude.track;
 
 export const [Track] = createTracker({
   init: () => {
-    if (API_KEY === undefined) {
-      throw new Error("NO API KEY");
-    }
-    if (!isDev)
+    if (!isDev) {
+      if (API_KEY === undefined) {
+        throw new Error("NO API KEY");
+      }
       amplitude.init(API_KEY, {
         autocapture: false,
       });
+    }
   },
   pageView: {
     onPageView: (params: EventParams, context: Context) => {

--- a/docs/src/tracker/createTracker.ts
+++ b/docs/src/tracker/createTracker.ts
@@ -3,7 +3,7 @@ import { createTracker } from "@offlegacy/event-tracker";
 import * as amplitude from "@amplitude/analytics-browser";
 
 const API_KEY = process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY;
-const isDev = process.env.NODE_ENV === "development";
+const isProduction = process.env.NODE_ENV === "production";
 
 interface Context {
   referrer?: string;
@@ -14,11 +14,11 @@ interface EventParams {
   target?: string;
 }
 
-const track = isDev ? console.log : amplitude.track;
+const track = isProduction ? amplitude.track : console.log;
 
 export const [Track] = createTracker({
   init: () => {
-    if (!isDev) {
+    if (isProduction) {
       if (API_KEY === undefined) {
         throw new Error("NO API KEY");
       }


### PR DESCRIPTION
## Description

This PR fixes `NO API KEY` Error in local development environment, that's caused when there is no Amplitude api key.
This key is not mandatory in local development environment, so it should only throw error when it is production.

<img width="598" alt="스크린샷 2025-05-12 오후 10 23 31" src="https://github.com/user-attachments/assets/b4b525ab-868b-4dd7-826b-fbeb1c0ea893" />

