### PR TITLE
fix(docs): add missing import statement in HomePage example (basic-example)

### DIFF
--- a/docs/offlegacy.org/src/content/en/docs/basic-example.mdx
+++ b/docs/offlegacy.org/src/content/en/docs/basic-example.mdx
@@ -53,7 +53,9 @@ function App() {
 
 Use the `Track.Click` component to declaratively track click events.
 
-```tsx {7-11, 13}
+```tsx {9-13, 15}
+import { Track } from "./tracker";
+
 function HomePage() {
   return (
     <main>

--- a/docs/offlegacy.org/src/content/ko/docs/basic-example.mdx
+++ b/docs/offlegacy.org/src/content/ko/docs/basic-example.mdx
@@ -53,7 +53,9 @@ function App() {
 
 `Track.Click` 컴포넌트를 이용해 선언적으로 클릭 이벤트를 트래킹합니다.
 
-```tsx {7-11, 13}
+```tsx {9-13, 15}
+import { Track } from "./tracker";
+
 function HomePage() {
   return (
     <main>


### PR DESCRIPTION
This PR fixes the HomePage example in `basic-example.mdx` by adding a missing import statement:

```diff
+ import { Track } from "./tracker";
```

**Before**
<img width="852" height="485" alt="image" src="https://github.com/user-attachments/assets/a1988eef-5a08-496e-80db-1bb4b74b5fd4" />

**After**
<img width="843" height="516" alt="스크린샷 2025-08-19 오전 9 29 11" src="https://github.com/user-attachments/assets/12c2506d-3823-435a-ae08-e36057074505" />
